### PR TITLE
Fixed problems with Multiplayer Lobbys, and Battery Percentage plus tweaked code a little

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -65,7 +65,7 @@ LOCAL_SHARED_LIBRARIES += codegen_0_6_2
 LOCAL_SHARED_LIBRARIES += questui
 LOCAL_SHARED_LIBRARIES += custom-types
 LOCAL_LDLIBS += -llog
-LOCAL_CFLAGS += -I'extern/libil2cpp/il2cpp/libil2cpp' -DID='"clockmod"' -DVERSION='"0.1.3"' -I'./shared' -I'./extern' -isystem'extern/codegen/include'
+LOCAL_CFLAGS += -I'extern/libil2cpp/il2cpp/libil2cpp' -DID='"clockmod"' -DVERSION='"0.1.3.1"' -I'./shared' -I'./extern' -isystem'extern/codegen/include'
 LOCAL_CPPFLAGS += -std=c++2a
 LOCAL_C_INCLUDES += ./include ./src
 include $(BUILD_SHARED_LIBRARY)

--- a/Android.mk
+++ b/Android.mk
@@ -65,7 +65,7 @@ LOCAL_SHARED_LIBRARIES += codegen_0_6_2
 LOCAL_SHARED_LIBRARIES += questui
 LOCAL_SHARED_LIBRARIES += custom-types
 LOCAL_LDLIBS += -llog
-LOCAL_CFLAGS += -I'extern/libil2cpp/il2cpp/libil2cpp' -DID='"clockmod"' -DVERSION='"0.1.3.1"' -I'./shared' -I'./extern' -isystem'extern/codegen/include'
+LOCAL_CFLAGS += -I'extern/libil2cpp/il2cpp/libil2cpp' -DID='"clockmod"' -DVERSION='"1.3.0"' -I'./shared' -I'./extern' -isystem'extern/codegen/include'
 LOCAL_CPPFLAGS += -std=c++2a
 LOCAL_C_INCLUDES += ./include ./src
 include $(BUILD_SHARED_LIBRARY)

--- a/bmbfmod.json
+++ b/bmbfmod.json
@@ -1,7 +1,7 @@
 {
   "id": "clockmod",
   "name": "Clock Mod",
-  "version": "0.1.3.1",
+  "version": "1.3.0",
   "author": "BoopetyDoopety, EnderdracheLP",
   "description": [
     "Displays the time in game."

--- a/bmbfmod.json
+++ b/bmbfmod.json
@@ -1,7 +1,7 @@
 {
   "id": "clockmod",
   "name": "Clock Mod",
-  "version": "0.1.3",
+  "version": "0.1.3.1",
   "author": "BoopetyDoopety, EnderdracheLP",
   "description": [
     "Displays the time in game."

--- a/debugstart.bat
+++ b/debugstart.bat
@@ -1,0 +1,8 @@
+"C:\Users\%username%\AppData\Roaming\SideQuest\platform-tools\adb.exe" shell am force-stop com.beatgames.beatsaber
+
+powershell ./build.ps1
+
+"C:\Users\%username%\AppData\Roaming\SideQuest\platform-tools\adb.exe" push libs/arm64-v8a/libclockmod.so /sdcard/Android/data/com.beatgames.beatsaber/files/mods/libclockmod.so
+
+"C:\Users\%username%\AppData\Roaming\SideQuest\platform-tools\adb.exe" shell am start com.beatgames.beatsaber/com.unity3d.player.UnityPlayerActivity
+echo Done

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -48,11 +48,12 @@ void ClockMod::ClockUpdater::Update() {
        if (getConfig().config["BattToggle"].GetBool() == true) {
            float batterylvl = GlobalNamespace::OVRPlugin::OVRP_1_1_0::ovrp_GetSystemBatteryLevel();
            batterylvl = batterylvl * 100;
+           std::string batterylevel = string_format("%g", batterylvl);
            std::string tandb = timestr;
            tandb += " - ";
-           std::string batterylevel = std::to_string(batterylvl);
-           batterylevel.erase(batterylevel.find_last_not_of('0') + 1, std::string::npos);
-           batterylevel.erase(batterylevel.find_last_not_of('.') + 1, std::string::npos);
+//           std::string batterylevel = std::to_string(batterylvl);
+//           batterylevel.erase(batterylevel.find_last_not_of('0') + 1, std::string::npos);
+//           batterylevel.erase(batterylevel.find_last_not_of('.') + 1, std::string::npos);
            tandb += batterylevel;
            tandb += "%";
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,7 +137,7 @@ MAKE_HOOK_OFFSETLESS(PauseMenuManager_StartResumeAnimation, void, PauseMenuManag
 MAKE_HOOK_OFFSETLESS(MultiplayerLobbyController_ActivateMultiplayerLobby, void, MultiplayerLobbyController* self) {
     MultiplayerLobbyController_ActivateMultiplayerLobby(self);
 
-    layout->get_transform()->set_position(UnityEngine::Vector3(0, -0.45, 1.62));
+    layout->get_transform()->set_position(UnityEngine::Vector3(0, -0.05, 1.62));
     layout->get_transform()->set_localScale(UnityEngine::Vector3(0.35, 0.35, 0.35));
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,15 @@
 #include "main.hpp"
 
 
+
 #include "GlobalNamespace/MainMenuViewController.hpp"
 #include "GlobalNamespace/AudioTimeSyncController.hpp"
 #include "GlobalNamespace/PauseMenuManager.hpp"
 #include "GlobalNamespace/SoloFreePlayFlowCoordinator.hpp"
 #include "GlobalNamespace/MultiplayerLobbyController.hpp"
+#include "GlobalNamespace/HostLobbySetupViewController.hpp"
+#include "GlobalNamespace/ClientLobbySetupViewController.hpp"
+#include "GlobalNamespace/QuickPlaySetupViewController.hpp"
 using namespace GlobalNamespace;
 
 #include "TMPro/TextMeshPro.hpp"
@@ -134,11 +138,43 @@ MAKE_HOOK_OFFSETLESS(PauseMenuManager_StartResumeAnimation, void, PauseMenuManag
     }
 }
 
+// Multiplayer Lobby Specific Code
+
 MAKE_HOOK_OFFSETLESS(MultiplayerLobbyController_ActivateMultiplayerLobby, void, MultiplayerLobbyController* self) {
     MultiplayerLobbyController_ActivateMultiplayerLobby(self);
 
-    layout->get_transform()->set_position(UnityEngine::Vector3(0, -0.05, 1.62));
+ //   layout->get_transform()->set_position(UnityEngine::Vector3(0, -0.05, 1.62));
+ //   layout->get_transform()->set_localScale(UnityEngine::Vector3(0.35, 0.35, 0.35));
+}
+
+MAKE_HOOK_OFFSETLESS(QuickPlaySetupViewController_DidActivate, void, QuickPlaySetupViewController* self, bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling) {
+    QuickPlaySetupViewController_DidActivate(self, firstActivation, addedToHierarchy, screenSystemEnabling);
+
+    auto MLobbyVCPosY = UnityEngine::Object::FindObjectOfType<HostLobbySetupViewController*>()->get_transform()->get_position().y;
+    MLobbyVCPosY = MLobbyVCPosY - 1;
+    logger().debug("%g", MLobbyVCPosY);
+    layout->get_transform()->set_position(UnityEngine::Vector3(0, MLobbyVCPosY, 1.62));
     layout->get_transform()->set_localScale(UnityEngine::Vector3(0.35, 0.35, 0.35));
+}
+
+MAKE_HOOK_OFFSETLESS(ClientLobbySetupViewController_DidActivate, void, ClientLobbySetupViewController* self, bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling) {
+    ClientLobbySetupViewController_DidActivate(self, firstActivation, addedToHierarchy, screenSystemEnabling);
+
+    auto MLobbyVCPosY = UnityEngine::Object::FindObjectOfType<HostLobbySetupViewController*>()->get_transform()->get_position().y;
+    MLobbyVCPosY = MLobbyVCPosY - 1;
+    logger().debug("%g", MLobbyVCPosY);
+    layout->get_transform()->set_position(UnityEngine::Vector3(0, MLobbyVCPosY, 1.62));
+    layout->get_transform()->set_localScale(UnityEngine::Vector3(0.35, 0.35, 0.35));
+}
+
+MAKE_HOOK_OFFSETLESS(HostLobbySetupViewController_DidActivate, void, HostLobbySetupViewController* self, bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling) {
+    HostLobbySetupViewController_DidActivate(self, firstActivation, addedToHierarchy, screenSystemEnabling);
+
+        auto MLobbyVCPosY = UnityEngine::Object::FindObjectOfType<HostLobbySetupViewController*>()->get_transform()->get_position().y;
+        MLobbyVCPosY = MLobbyVCPosY - 1;
+        logger().debug("%g", MLobbyVCPosY);
+        layout->get_transform()->set_position(UnityEngine::Vector3(0, MLobbyVCPosY, 1.62));
+        layout->get_transform()->set_localScale(UnityEngine::Vector3(0.35, 0.35, 0.35));
 }
 
 MAKE_HOOK_OFFSETLESS(MultiplayerLobbyController_DeactivateMultiplayerLobby, void, MultiplayerLobbyController* self) {
@@ -210,7 +246,11 @@ extern "C" void load() {
     INSTALL_HOOK_OFFSETLESS(hookLogger, SoloFreePlayFlowCoordinator_SinglePlayerLevelSelectionFlowCoordinatorDidActivate, il2cpp_utils::FindMethodUnsafe("", "SoloFreePlayFlowCoordinator", "SinglePlayerLevelSelectionFlowCoordinatorDidActivate", 2));
     INSTALL_HOOK_OFFSETLESS(hookLogger, PauseMenuManager_ShowMenu, il2cpp_utils::FindMethodUnsafe("", "PauseMenuManager", "ShowMenu", 0));
     INSTALL_HOOK_OFFSETLESS(hookLogger, PauseMenuManager_StartResumeAnimation, il2cpp_utils::FindMethodUnsafe("", "PauseMenuManager", "StartResumeAnimation", 0));
-    INSTALL_HOOK_OFFSETLESS(hookLogger, MultiplayerLobbyController_ActivateMultiplayerLobby, il2cpp_utils::FindMethodUnsafe("", "MultiplayerLobbyController", "ActivateMultiplayerLobby", 0));
+//    INSTALL_HOOK_OFFSETLESS(hookLogger, MultiplayerLobbyController_ActivateMultiplayerLobby, il2cpp_utils::FindMethodUnsafe("", "MultiplayerLobbyController", "ActivateMultiplayerLobby", 0));
+    // Multiplayer specific Hooks
+    INSTALL_HOOK_OFFSETLESS(hookLogger, HostLobbySetupViewController_DidActivate, il2cpp_utils::FindMethodUnsafe("", "HostLobbySetupViewController", "DidActivate", 3));
+    INSTALL_HOOK_OFFSETLESS(hookLogger, ClientLobbySetupViewController_DidActivate, il2cpp_utils::FindMethodUnsafe("", "ClientLobbySetupViewController", "DidActivate", 3));
+    INSTALL_HOOK_OFFSETLESS(hookLogger, QuickPlaySetupViewController_DidActivate, il2cpp_utils::FindMethodUnsafe("", "QuickPlaySetupViewController", "DidActivate", 3));
     INSTALL_HOOK_OFFSETLESS(hookLogger, MultiplayerLobbyController_DeactivateMultiplayerLobby, il2cpp_utils::FindMethodUnsafe("", "MultiplayerLobbyController", "DeactivateMultiplayerLobby", 0));
 
     logger().info("Installed all ClockMod hooks!");


### PR DESCRIPTION
The clock should now always be positioned above the Lobby Menu, the hooks for the menus are different between Host, Client and QuickPlay, host part works so far Client and Quickplay still untested, this will fix #6.

The Battery Percentage should now always be without any extra decimals which will fix #5.

Tweaked code for Battery Percentage calculations.

Versioning has been changed, to now be semtantic versioning.