### PR TITLE
Added session time and stopwatches

### DIFF
--- a/include/ClockModConfig.hpp
+++ b/include/ClockModConfig.hpp
@@ -3,6 +3,7 @@
 
 DECLARE_CONFIG(ModConfig) {
 
+    CONFIG_VALUE(ClockType,     int,   "Clock Type",                  0,     "Which time the Clock should display.");
     CONFIG_VALUE(InSong,        bool,  "Show During Song",            true,  "If the Clock should be shown while playing a beatmap.");
     CONFIG_VALUE(InReplay,      bool,  "Show During Replay",          true,  "If the Clock should be shown while playing a replay.");
     CONFIG_VALUE(TwelveToggle,  bool,  "24/12 Toggle",                false, "If time should be in 12 or 24 hour format.");

--- a/include/ClockModConfig.hpp
+++ b/include/ClockModConfig.hpp
@@ -4,8 +4,10 @@
 DECLARE_CONFIG(ModConfig) {
 
     CONFIG_VALUE(ClockType,          int,    "Clock Type",                  0,     "Which time the Clock should display.");
-    CONFIG_VALUE(StopwatchSeconds,   int,    "Stopwatch Seconds",           0,     "The saved time on the stopwatch.");
-    CONFIG_VALUE(StopwatchPaused,    bool,   "Stopwatch Paused",            true,  "If the stopwatch is locked from incrementing.")
+    CONFIG_VALUE(Stopwatch1Seconds,  int,    "Stopwatch 1 Seconds",         0,     "The saved time on stopwatch 1.");
+    CONFIG_VALUE(Stopwatch2Seconds,  int,    "Stopwatch 2 Seconds",         0,     "The saved time on stopwatch 2.");
+    CONFIG_VALUE(Stopwatch1Paused,   bool,   "Stopwatch 1 Paused",          true,  "If stopwatch 1 is locked from incrementing.");
+    CONFIG_VALUE(Stopwatch2Paused,   bool,   "Stopwatch 2 Paused",          true,  "If stopwatch 2 is locked from incrementing.");
     CONFIG_VALUE(InSong,             bool,   "Show During Song",            true,  "If the Clock should be shown while playing a beatmap.");
     CONFIG_VALUE(InReplay,           bool,   "Show During Replay",          true,  "If the Clock should be shown while playing a replay.");
     CONFIG_VALUE(TwelveToggle,       bool,   "24/12 Toggle",                false, "If time should be in 12 or 24 hour format.");

--- a/include/ClockModConfig.hpp
+++ b/include/ClockModConfig.hpp
@@ -3,15 +3,17 @@
 
 DECLARE_CONFIG(ModConfig) {
 
-    CONFIG_VALUE(ClockType,     int,   "Clock Type",                  0,     "Which time the Clock should display.");
-    CONFIG_VALUE(InSong,        bool,  "Show During Song",            true,  "If the Clock should be shown while playing a beatmap.");
-    CONFIG_VALUE(InReplay,      bool,  "Show During Replay",          true,  "If the Clock should be shown while playing a replay.");
-    CONFIG_VALUE(TwelveToggle,  bool,  "24/12 Toggle",                false, "If time should be in 12 or 24 hour format.");
-    CONFIG_VALUE(SecToggle,     bool,  "Show Seconds",                false, "If seconds should be displayed.");
-    CONFIG_VALUE(BattToggle,    bool,  "Show Battery Percentage",     false, "Displays Battery percentage next to the clock.");
-    CONFIG_VALUE(RainbowClock,  bool,  "Rainbowify it",               false, "Makes the Clock beautiful.");
-    CONFIG_VALUE(FontSize,      float, "Font Size",                   3.5,   "Changes the Font Size of the Clock (Default: 3.5)");
-    CONFIG_VALUE(ClockPosition, bool,  "Clock Position (Top/Bottom)", false, "If the Clock should be at the top or the bottom");
+    CONFIG_VALUE(ClockType,          int,    "Clock Type",                  0,     "Which time the Clock should display.");
+    CONFIG_VALUE(StopwatchSeconds,   double, "Stopwatch Seconds",           0,     "The saved time on the stopwatch.");
+    CONFIG_VALUE(StopwatchPaused,    bool,   "Stopwatch Paused",            true,  "If the stopwatch is locked from incrementing.")
+    CONFIG_VALUE(InSong,             bool,   "Show During Song",            true,  "If the Clock should be shown while playing a beatmap.");
+    CONFIG_VALUE(InReplay,           bool,   "Show During Replay",          true,  "If the Clock should be shown while playing a replay.");
+    CONFIG_VALUE(TwelveToggle,       bool,   "24/12 Toggle",                false, "If time should be in 12 or 24 hour format.");
+    CONFIG_VALUE(SecToggle,          bool,   "Show Seconds",                false, "If seconds should be displayed.");
+    CONFIG_VALUE(BattToggle,         bool,   "Show Battery Percentage",     false, "Displays Battery percentage next to the clock.");
+    CONFIG_VALUE(RainbowClock,       bool,   "Rainbowify it",               false, "Makes the Clock beautiful.");
+    CONFIG_VALUE(FontSize,           float,  "Font Size",                   3.5,   "Changes the Font Size of the Clock (Default: 3.5)");
+    CONFIG_VALUE(ClockPosition,      bool,   "Clock Position (Top/Bottom)", false, "If the Clock should be at the top or the bottom");
 
 //    CONFIG_VALUE(ClockXOffset, double, "Clock X Offset", 0);
 //    CONFIG_VALUE(ClockYOffset, double, "Clock Y Offset", 0);

--- a/include/ClockModConfig.hpp
+++ b/include/ClockModConfig.hpp
@@ -4,7 +4,7 @@
 DECLARE_CONFIG(ModConfig) {
 
     CONFIG_VALUE(ClockType,          int,    "Clock Type",                  0,     "Which time the Clock should display.");
-    CONFIG_VALUE(StopwatchSeconds,   double, "Stopwatch Seconds",           0,     "The saved time on the stopwatch.");
+    CONFIG_VALUE(StopwatchSeconds,   int,    "Stopwatch Seconds",           0,     "The saved time on the stopwatch.");
     CONFIG_VALUE(StopwatchPaused,    bool,   "Stopwatch Paused",            true,  "If the stopwatch is locked from incrementing.")
     CONFIG_VALUE(InSong,             bool,   "Show During Song",            true,  "If the Clock should be shown while playing a beatmap.");
     CONFIG_VALUE(InReplay,           bool,   "Show During Replay",          true,  "If the Clock should be shown while playing a replay.");

--- a/include/ClockValues.hpp
+++ b/include/ClockValues.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "UnityEngine/Vector3.hpp"
 #include "UnityEngine/UI/VerticalLayoutGroup.hpp"
+#include <string_view>
 
 enum class ClockTypes {
     CurrentTime,

--- a/include/ClockValues.hpp
+++ b/include/ClockValues.hpp
@@ -5,12 +5,14 @@
 enum class ClockTypes {
     CurrentTime,
     SessionTime,
-    Stopwatch
+    Stopwatch1,
+    Stopwatch2
 };
 static std::string_view clockTypeStrs[] = {
     "Current Time",
     "Session Time",
-    "Stopwatch"
+    "Stopwatch 1",
+    "Stopwatch 2",
 };
 
 // This containts all the ClockPositions

--- a/include/ClockValues.hpp
+++ b/include/ClockValues.hpp
@@ -4,13 +4,13 @@
 
 enum class ClockTypes {
     CurrentTime,
-    SessionTime
-    // CustomTimer
+    SessionTime,
+    Stopwatch
 };
 static std::string_view clockTypeStrs[] = {
     "Current Time",
-    "Session Time"
-    // Custom Timer
+    "Session Time",
+    "Stopwatch"
 };
 
 // This containts all the ClockPositions

--- a/include/ClockValues.hpp
+++ b/include/ClockValues.hpp
@@ -2,6 +2,17 @@
 #include "UnityEngine/Vector3.hpp"
 #include "UnityEngine/UI/VerticalLayoutGroup.hpp"
 
+enum class ClockTypes {
+    CurrentTime,
+    SessionTime
+    // CustomTimer
+};
+static std::string_view clockTypeStrs[] = {
+    "Current Time",
+    "Session Time"
+    // Custom Timer
+};
+
 // This containts all the ClockPositions
 struct ClockPos_t {
     // Clock InMenu Positions Top                                           X        Y        Z

--- a/qpm.json
+++ b/qpm.json
@@ -6,7 +6,7 @@
   "info": {
     "name": "Clock Mod",
     "id": "ClockMod",
-    "version": "1.11.0-Dev",
+    "version": "1.15.0-Dev",
     "url": null,
     "additionalData": {
       "overrideSoName": "libClockMod.so",

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -7,7 +7,7 @@
     "info": {
       "name": "Clock Mod",
       "id": "ClockMod",
-      "version": "1.11.0-Dev",
+      "version": "1.15.0-Dev",
       "url": null,
       "additionalData": {
         "overrideSoName": "libClockMod.so",

--- a/shared/ClockUpdater.hpp
+++ b/shared/ClockUpdater.hpp
@@ -27,7 +27,7 @@ private:
     time_t rawtime;
     struct tm* timeinfo;
 
-    double sessionTime = 0;
+    double sessionTimeSeconds = 0;
 
     static ClockUpdater* instance;
 
@@ -38,7 +38,7 @@ public:
     const time_t getRawTime() const;
     struct tm* getTimeInfo();
     struct tm* getTimeInfoUTC();
-    const double getSessionTime() const;
+    const double getSessionTimeSeconds() const;
     TMPro::TextMeshProUGUI* getTextMesh();
     void SetColor(UnityEngine::Color color);
     static ClockUpdater* getInstance();

--- a/shared/ClockUpdater.hpp
+++ b/shared/ClockUpdater.hpp
@@ -28,7 +28,8 @@ private:
     struct tm* timeinfo;
 
     double sessionTimeSeconds = 0;
-    double stopwatchSeconds = 0;
+    double stopwatch1Seconds = 0;
+    double stopwatch2Seconds = 0;
 
     static ClockUpdater* instance;
 
@@ -40,8 +41,10 @@ public:
     struct tm* getTimeInfo();
     struct tm* getTimeInfoUTC();
     const double getSessionTimeSeconds() const;
-    const double getStopwatchSeconds() const;
-    void resetStopwatch();
+    const double getStopwatch1Seconds() const;
+    const double getStopwatch2Seconds() const;
+    void resetStopwatch1();
+    void resetStopwatch2();
     TMPro::TextMeshProUGUI* getTextMesh();
     void SetColor(UnityEngine::Color color);
     static ClockUpdater* getInstance();

--- a/shared/ClockUpdater.hpp
+++ b/shared/ClockUpdater.hpp
@@ -41,6 +41,7 @@ public:
     struct tm* getTimeInfoUTC();
     const double getSessionTimeSeconds() const;
     const double getStopwatchSeconds() const;
+    void resetStopwatch();
     TMPro::TextMeshProUGUI* getTextMesh();
     void SetColor(UnityEngine::Color color);
     static ClockUpdater* getInstance();

--- a/shared/ClockUpdater.hpp
+++ b/shared/ClockUpdater.hpp
@@ -38,10 +38,12 @@ public:
     const time_t getRawTime() const;
     struct tm* getTimeInfo();
     struct tm* getTimeInfoUTC();
+    const double getSessionTime() const;
     TMPro::TextMeshProUGUI* getTextMesh();
     void SetColor(UnityEngine::Color color);
     static ClockUpdater* getInstance();
     static std::string getTimeFormat();
+    static std::string getTimerString(const double totalSeconds);
     void ShowMessage(std::string message, int duration = 4);
 
 };

--- a/shared/ClockUpdater.hpp
+++ b/shared/ClockUpdater.hpp
@@ -28,6 +28,7 @@ private:
     struct tm* timeinfo;
 
     double sessionTimeSeconds = 0;
+    double stopwatchSeconds = 0;
 
     static ClockUpdater* instance;
 
@@ -39,6 +40,7 @@ public:
     struct tm* getTimeInfo();
     struct tm* getTimeInfoUTC();
     const double getSessionTimeSeconds() const;
+    const double getStopwatchSeconds() const;
     TMPro::TextMeshProUGUI* getTextMesh();
     void SetColor(UnityEngine::Color color);
     static ClockUpdater* getInstance();

--- a/shared/ClockUpdater.hpp
+++ b/shared/ClockUpdater.hpp
@@ -27,6 +27,8 @@ private:
     time_t rawtime;
     struct tm* timeinfo;
 
+    double sessionTime = 0;
+
     static ClockUpdater* instance;
 
     std::string _message;

--- a/shared/ClockUpdater.hpp
+++ b/shared/ClockUpdater.hpp
@@ -49,7 +49,7 @@ public:
     void SetColor(UnityEngine::Color color);
     static ClockUpdater* getInstance();
     static std::string getTimeFormat();
-    static std::string getTimerString(const double totalSeconds);
+    static std::string getStopwatchString(const double totalSeconds);
     void ShowMessage(std::string message, int duration = 4);
 
 };

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -301,6 +301,10 @@ namespace ClockMod {
         return stopwatchSeconds;
     }
 
+    void ClockUpdater::resetStopwatch() {
+        stopwatchSeconds = 0;
+    }
+
     TMPro::TextMeshProUGUI* ClockUpdater::getTextMesh() {
         return text;
     }

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -10,6 +10,7 @@
 #include "UnityEngine/BatteryStatus.hpp"
 #include "UnityEngine/GradientColorKey.hpp"
 #include "UnityEngine/SystemInfo.hpp"
+#include "UnityEngine/Time.hpp"
 
 using namespace UnityEngine;
 using namespace TMPro;
@@ -208,6 +209,8 @@ namespace ClockMod {
         time_counter += (double)(this_time - last_time);
 
         last_time = this_time;
+
+        sessionTime = Time::get_realtimeSinceStartup();
 
         if (!(time_counter > (double)(NUM_SECONDS * CLOCKS_PER_SEC)))
         {

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -53,6 +53,24 @@ namespace ClockMod {
         return time;
     }
 
+    // Turns an uncapped duration in seconds into a nicely formatted string
+    std::string getTimerString(double totalSeconds) {
+        int seconds = (int)totalSeconds % 60;
+        int minutes = (int)(totalSeconds / 60) % 60;
+        int hours = (int)(totalSeconds / 60 / 60) % 24;
+        int days = (int)(totalSeconds / 60 / 60 / 24);
+
+        bool showSeconds = getModConfig().SecToggle.GetValue();
+
+        std::string timerStr;
+        if(days > 0) timerStr += fmt::format("{}:", days);
+        if(hours > 0 || !timerStr.empty() || !showSeconds) timerStr += fmt::format("{:02}:", hours);
+        timerStr += fmt::format("{:02}", minutes);
+        if(showSeconds) timerStr += fmt::format(":{:02}", seconds);
+
+        return timerStr;
+    }
+
     // New Battery Percentage Formatting
     std::string getBatteryString(float level, UnityEngine::BatteryStatus status, ClockMod::ClockUpdater* instance)
     {

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -205,12 +205,15 @@ namespace ClockMod {
             text->get_transform()->set_localScale(UnityEngine::Vector3(1, 1, 1));
         }
 
+        static double lastSessionTimeSeconds = Time::get_realtimeSinceStartup();
+
         this_time = clock();
         sessionTimeSeconds = Time::get_realtimeSinceStartup();
-        if(!getModConfig().StopwatchPaused.GetValue()) stopwatchSeconds += (double)(this_time - last_time) / CLOCKS_PER_SEC;
+        if(!getModConfig().StopwatchPaused.GetValue()) stopwatchSeconds += sessionTimeSeconds - lastSessionTimeSeconds;
         time_counter += (double)(this_time - last_time);
 
         last_time = this_time;
+        lastSessionTimeSeconds = sessionTimeSeconds;
 
         if (!(time_counter > (double)(NUM_SECONDS * CLOCKS_PER_SEC)))
         {

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -226,7 +226,7 @@ namespace ClockMod {
         // Scuffed, but not any more than the rest of this codebase
         static int stopwatchSaveTimer = 0;
         stopwatchSaveTimer++;
-        if(stopwatchSaveTimer > 10 / NUM_SECONDS && !Config.IsInSong) { // Avoid dropping frames during gameplay
+        if(stopwatchSaveTimer > 5 / NUM_SECONDS && !Config.IsInSong) { // Avoid dropping frames during gameplay
             getModConfig().Stopwatch1Seconds.SetValue(stopwatch1Seconds);
             getModConfig().Stopwatch2Seconds.SetValue(stopwatch2Seconds);
             stopwatchSaveTimer = 0;

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -231,14 +231,9 @@ namespace ClockMod {
             ClockPos.ap1 = (timeinfo && timeinfo->tm_mon == 3 && timeinfo->tm_mday == 1);
 
             std::string clockresult;
-
-            if (_message.empty()) {
-                // Gets the time using the function at the top.
-                clockresult = getTimeString((struct tm*)timeinfo);
-            } 
-            else {
-                clockresult = _message;
-            }
+            if(!_message.empty()) clockresult = _message;
+            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::SessionTime)) clockresult = getTimerString(sessionTime);
+            else clockresult = getTimeString((struct tm*)timeinfo);
 
             // Checks, if the clock is set to rainbowify
             if (getModConfig().RainbowClock.GetValue()) {

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -155,7 +155,8 @@ namespace ClockMod {
 
         text = get_gameObject()->GetComponent<TextMeshProUGUI*>();
         clockParent = get_transform()->GetParent();
-        stopwatchSeconds = getModConfig().StopwatchSeconds.GetValue();
+        stopwatch1Seconds = getModConfig().Stopwatch1Seconds.GetValue();
+        stopwatch2Seconds = getModConfig().Stopwatch2Seconds.GetValue();
         getModConfig().ClockColor.AddChangeEvent([this](UnityEngine::Color color) {
             if (text)
                 text->set_color(color);
@@ -209,7 +210,8 @@ namespace ClockMod {
 
         this_time = clock();
         sessionTimeSeconds = Time::get_realtimeSinceStartup();
-        if(!getModConfig().StopwatchPaused.GetValue()) stopwatchSeconds += sessionTimeSeconds - lastSessionTimeSeconds;
+        if(!getModConfig().Stopwatch1Paused.GetValue()) stopwatch1Seconds += sessionTimeSeconds - lastSessionTimeSeconds;
+        if(!getModConfig().Stopwatch2Paused.GetValue()) stopwatch2Seconds += sessionTimeSeconds - lastSessionTimeSeconds;
         time_counter += (double)(this_time - last_time);
 
         last_time = this_time;
@@ -225,7 +227,8 @@ namespace ClockMod {
         static int stopwatchSaveTimer = 0;
         stopwatchSaveTimer++;
         if(stopwatchSaveTimer > 10 / NUM_SECONDS && !Config.IsInSong) { // Avoid dropping frames during gameplay
-            getModConfig().StopwatchSeconds.SetValue(stopwatchSeconds);
+            getModConfig().Stopwatch1Seconds.SetValue(stopwatch1Seconds);
+            getModConfig().Stopwatch2Seconds.SetValue(stopwatch2Seconds);
             stopwatchSaveTimer = 0;
         }
 
@@ -244,7 +247,8 @@ namespace ClockMod {
             std::string clockresult;
             if(!_message.empty()) clockresult = _message;
             else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::SessionTime)) clockresult = getTimerString(sessionTimeSeconds);
-            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::Stopwatch)) clockresult = getTimerString(stopwatchSeconds);
+            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::Stopwatch1)) clockresult = getTimerString(stopwatch1Seconds);
+            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::Stopwatch2)) clockresult = getTimerString(stopwatch2Seconds);
             else clockresult = getTimeString((struct tm*)timeinfo);
 
             // Checks, if the clock is set to rainbowify
@@ -297,12 +301,20 @@ namespace ClockMod {
         return sessionTimeSeconds;
     }
 
-    const double ClockUpdater::getStopwatchSeconds() const {
-        return stopwatchSeconds;
+    const double ClockUpdater::getStopwatch1Seconds() const {
+        return stopwatch1Seconds;
     }
 
-    void ClockUpdater::resetStopwatch() {
-        stopwatchSeconds = 0;
+    const double ClockUpdater::getStopwatch2Seconds() const {
+        return stopwatch2Seconds;
+    }
+
+    void ClockUpdater::resetStopwatch1() {
+        stopwatch1Seconds = 0;
+    }
+
+    void ClockUpdater::resetStopwatch2() {
+        stopwatch2Seconds = 0;
     }
 
     TMPro::TextMeshProUGUI* ClockUpdater::getTextMesh() {

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -205,12 +205,11 @@ namespace ClockMod {
         }
 
         this_time = clock();
-
+        sessionTimeSeconds = Time::get_realtimeSinceStartup();
+        if(!getModConfig().StopwatchPaused.GetValue()) stopwatchSeconds += (double)(this_time - last_time) / CLOCKS_PER_SEC;
         time_counter += (double)(this_time - last_time);
 
         last_time = this_time;
-
-        sessionTimeSeconds = Time::get_realtimeSinceStartup();
 
         if (!(time_counter > (double)(NUM_SECONDS * CLOCKS_PER_SEC)))
         {
@@ -233,6 +232,7 @@ namespace ClockMod {
             std::string clockresult;
             if(!_message.empty()) clockresult = _message;
             else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::SessionTime)) clockresult = getTimerString(sessionTimeSeconds);
+            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::Stopwatch)) clockresult = getTimerString(stopwatchSeconds);
             else clockresult = getTimeString((struct tm*)timeinfo);
 
             // Checks, if the clock is set to rainbowify
@@ -283,6 +283,10 @@ namespace ClockMod {
 
     const double ClockUpdater::getSessionTimeSeconds() const {
         return sessionTimeSeconds;
+    }
+
+    const double ClockUpdater::getStopwatchSeconds() const {
+        return stopwatchSeconds;
     }
 
     TMPro::TextMeshProUGUI* ClockUpdater::getTextMesh() {

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -65,8 +65,8 @@ namespace ClockMod {
 
         std::string timerStr;
         if(days > 0) timerStr += fmt::format("{}:", days);
-        if(hours > 0 || !timerStr.empty() || !showSeconds) timerStr += fmt::format("{:02}:", hours);
-        timerStr += fmt::format("{:02}", minutes);
+        if(hours > 0 || !timerStr.empty() || !showSeconds) timerStr += timerStr.empty() ? fmt::format("{}:", hours) : fmt::format("{:02}:", hours);
+        timerStr += timerStr.empty() ? fmt::format("{}", minutes) : fmt::format("{:02}", minutes);
         if(showSeconds) timerStr += fmt::format(":{:02}", seconds);
 
         return timerStr;

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -55,7 +55,7 @@ namespace ClockMod {
     }
 
     // Turns an uncapped duration in seconds into a nicely formatted string
-    std::string ClockUpdater::getTimerString(const double totalSeconds) {
+    std::string ClockUpdater::getStopwatchString(const double totalSeconds) {
         int seconds = (int)totalSeconds % 60;
         int minutes = (int)(totalSeconds / 60) % 60;
         int hours = (int)(totalSeconds / 60 / 60) % 24;
@@ -63,13 +63,13 @@ namespace ClockMod {
 
         bool showSeconds = getModConfig().SecToggle.GetValue();
 
-        std::string timerStr;
-        if(days > 0) timerStr += fmt::format("{}:", days);
-        if(hours > 0 || !timerStr.empty() || !showSeconds) timerStr += timerStr.empty() ? fmt::format("{}:", hours) : fmt::format("{:02}:", hours);
-        timerStr += timerStr.empty() ? fmt::format("{}", minutes) : fmt::format("{:02}", minutes);
-        if(showSeconds) timerStr += fmt::format(":{:02}", seconds);
+        std::string stopwatchStr;
+        if(days > 0) stopwatchStr += fmt::format("{}:", days);
+        if(hours > 0 || !stopwatchStr.empty() || !showSeconds) stopwatchStr += stopwatchStr.empty() ? fmt::format("{}:", hours) : fmt::format("{:02}:", hours);
+        stopwatchStr += stopwatchStr.empty() ? fmt::format("{}", minutes) : fmt::format("{:02}", minutes);
+        if(showSeconds) stopwatchStr += fmt::format(":{:02}", seconds);
 
-        return timerStr;
+        return stopwatchStr;
     }
 
     // New Battery Percentage Formatting
@@ -246,9 +246,9 @@ namespace ClockMod {
 
             std::string clockresult;
             if(!_message.empty()) clockresult = _message;
-            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::SessionTime)) clockresult = getTimerString(sessionTimeSeconds);
-            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::Stopwatch1)) clockresult = getTimerString(stopwatch1Seconds);
-            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::Stopwatch2)) clockresult = getTimerString(stopwatch2Seconds);
+            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::SessionTime)) clockresult = getStopwatchString(sessionTimeSeconds);
+            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::Stopwatch1)) clockresult = getStopwatchString(stopwatch1Seconds);
+            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::Stopwatch2)) clockresult = getStopwatchString(stopwatch2Seconds);
             else clockresult = getTimeString((struct tm*)timeinfo);
 
             // Checks, if the clock is set to rainbowify

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -210,7 +210,7 @@ namespace ClockMod {
 
         last_time = this_time;
 
-        sessionTime = Time::get_realtimeSinceStartup();
+        sessionTimeSeconds = Time::get_realtimeSinceStartup();
 
         if (!(time_counter > (double)(NUM_SECONDS * CLOCKS_PER_SEC)))
         {
@@ -232,7 +232,7 @@ namespace ClockMod {
 
             std::string clockresult;
             if(!_message.empty()) clockresult = _message;
-            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::SessionTime)) clockresult = getTimerString(sessionTime);
+            else if(getModConfig().ClockType.GetValue() == static_cast<int>(ClockTypes::SessionTime)) clockresult = getTimerString(sessionTimeSeconds);
             else clockresult = getTimeString((struct tm*)timeinfo);
 
             // Checks, if the clock is set to rainbowify
@@ -281,8 +281,8 @@ namespace ClockMod {
         return gmtime(&time);
     }
 
-    const double ClockUpdater::getSessionTime() const {
-        return sessionTime;
+    const double ClockUpdater::getSessionTimeSeconds() const {
+        return sessionTimeSeconds;
     }
 
     TMPro::TextMeshProUGUI* ClockUpdater::getTextMesh() {

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -155,6 +155,7 @@ namespace ClockMod {
 
         text = get_gameObject()->GetComponent<TextMeshProUGUI*>();
         clockParent = get_transform()->GetParent();
+        stopwatchSeconds = getModConfig().StopwatchSeconds.GetValue();
         getModConfig().ClockColor.AddChangeEvent([this](UnityEngine::Color color) {
             if (text)
                 text->set_color(color);
@@ -216,6 +217,14 @@ namespace ClockMod {
             return;
         }
         time_counter = 0;
+
+        // Scuffed, but not any more than the rest of this codebase
+        static int stopwatchSaveTimer = 0;
+        stopwatchSaveTimer++;
+        if(stopwatchSaveTimer > 10 / NUM_SECONDS && !Config.IsInSong) { // Avoid dropping frames during gameplay
+            getModConfig().StopwatchSeconds.SetValue(stopwatchSeconds);
+            stopwatchSaveTimer = 0;
+        }
 
         if (getModConfig().InSong.GetValue() || !Config.noTextAndHUD) {
             time(&rawtime);

--- a/src/ClockUpdater.cpp
+++ b/src/ClockUpdater.cpp
@@ -55,7 +55,7 @@ namespace ClockMod {
     }
 
     // Turns an uncapped duration in seconds into a nicely formatted string
-    std::string getTimerString(double totalSeconds) {
+    std::string ClockUpdater::getTimerString(const double totalSeconds) {
         int seconds = (int)totalSeconds % 60;
         int minutes = (int)(totalSeconds / 60) % 60;
         int hours = (int)(totalSeconds / 60 / 60) % 24;
@@ -284,6 +284,10 @@ namespace ClockMod {
     struct tm* ClockUpdater::getTimeInfoUTC() {
         time_t time = rawtime;
         return gmtime(&time);
+    }
+
+    const double ClockUpdater::getSessionTime() const {
+        return sessionTime;
     }
 
     TMPro::TextMeshProUGUI* ClockUpdater::getTextMesh() {

--- a/src/ClockViewContoller.cpp
+++ b/src/ClockViewContoller.cpp
@@ -48,7 +48,7 @@ namespace ClockMod {
             strftime(UTCtime, sizeof(UTCtime), std::string("\r\nCurrent Time in UTC -  " + ClockUpdater::getTimeFormat()).c_str(), ClockUpdater::getInstance()->getTimeInfoUTC());
             //strftime(UTCtime, sizeof(UTCtime), std::string("\r\n Current Time in UTC -  " + ClockUpdater::getTimeFormat()).c_str(), gmtime(ClockUpdater::getInstance()->getRawTime()));
             
-            std::string sessionTime = "\nSession Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getSessionTime());
+            std::string sessionTime = "\nSession Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getSessionTimeSeconds());
 
             if (TimeInfo && SettingsOpen)
                 TimeInfo->set_text(std::string(timeInformation) + UTCtime + sessionTime);

--- a/src/ClockViewContoller.cpp
+++ b/src/ClockViewContoller.cpp
@@ -53,10 +53,11 @@ namespace ClockMod {
             
             std::string sessionTime = "\nSession Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getSessionTimeSeconds());
 
-            std::string stopwatchTime = "\nStopwatch Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getStopwatchSeconds());
+            std::string stopwatch1Time = "\nStopwatch 1 Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getStopwatch1Seconds());
+            std::string stopwatch2Time = "\nStopwatch 2 Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getStopwatch2Seconds());
 
             if (TimeInfo && SettingsOpen)
-                TimeInfo->set_text(std::string(timeInformation) + UTCtime + sessionTime + stopwatchTime);
+                TimeInfo->set_text(std::string(timeInformation) + UTCtime + sessionTime + stopwatch1Time + stopwatch2Time);
             co_yield reinterpret_cast<System::Collections::IEnumerator*>(UnityEngine::WaitForSecondsRealtime::New_ctor(0.1));
         }
         co_return;
@@ -77,7 +78,7 @@ namespace ClockMod {
                 std::string timeFormat = "Your Timezone -  %Z\nUTC offset -  %z";
                 strftime(timeInformation, sizeof(timeInformation), timeFormat.c_str(), instance->getTimeInfo());
                 // We have to specify sizeDelta here otherwise things will overlap
-                TimeInfo = BSML::Lite::CreateText(parent, std::string(timeInformation), TMPro::FontStyles::Normal, {0,0}, {0,5*5});
+                TimeInfo = BSML::Lite::CreateText(parent, std::string(timeInformation), TMPro::FontStyles::Normal, {0,0}, {0,5*6});
                 // TimeInfo = BSML::Lite::CreateText(parent, std::string(timeInformation), TMPro::FontStyles::Normal);
 
                 ColorPicker = BSML::Lite::CreateColorPickerModal(parent, getModConfig().ClockColor.GetName(), getModConfig().ClockColor.GetValue(),
@@ -93,17 +94,35 @@ namespace ClockMod {
                     );
             }
 
-            auto stopwatchPauseButton = BSML::Lite::CreateUIButton(parent, getModConfig().StopwatchPaused.GetValue() ? "Start" : "Pause", {68, -19.9}, {-5, 0}, nullptr);
-            stopwatchPauseButton->GetComponent<UI::LayoutElement*>()->set_ignoreLayout(true);
-            stopwatchPauseButton->get_onClick()->AddListener(custom_types::MakeDelegate<Events::UnityAction*>(std::function<void()>([stopwatchPauseButton](){
-                getModConfig().StopwatchPaused.SetValue(!getModConfig().StopwatchPaused.GetValue());
-                if(getModConfig().StopwatchPaused.GetValue()) BSML::Lite::SetButtonText(stopwatchPauseButton, "Start");
-                else BSML::Lite::SetButtonText(stopwatchPauseButton, "Pause");
+            // Could optimize these into a small lambda or #define, but there's only two as of now so it's not that big a deal
+            auto stopwatch1PauseButton = BSML::Lite::CreateUIButton(parent, getModConfig().Stopwatch1Paused.GetValue() ? "Start" : "Pause", {70, -19.9}, {-5, 0}, nullptr);
+            stopwatch1PauseButton->GetComponent<UI::LayoutElement*>()->set_ignoreLayout(true);
+            stopwatch1PauseButton->get_transform()->set_localScale({0.9, 0.9, 0.9});
+            stopwatch1PauseButton->get_onClick()->AddListener(custom_types::MakeDelegate<Events::UnityAction*>(std::function<void()>([stopwatch1PauseButton](){
+                getModConfig().Stopwatch1Paused.SetValue(!getModConfig().Stopwatch1Paused.GetValue());
+                if(getModConfig().Stopwatch1Paused.GetValue()) BSML::Lite::SetButtonText(stopwatch1PauseButton, "Start");
+                else BSML::Lite::SetButtonText(stopwatch1PauseButton, "Pause");
             })));
-            auto stopwatchResetButton = BSML::Lite::CreateUIButton(parent, "Reset", {83, -19.9}, {-5, 8}, nullptr);
-            stopwatchResetButton->GetComponent<UI::LayoutElement*>()->set_ignoreLayout(true);
-            stopwatchResetButton->get_onClick()->AddListener(custom_types::MakeDelegate<Events::UnityAction*>(std::function<void()>([](){
-                if(ClockMod::ClockUpdater::getInstance()) ClockMod::ClockUpdater::getInstance()->resetStopwatch();
+            auto stopwatch1ResetButton = BSML::Lite::CreateUIButton(parent, "Reset", {83.5, -19.9}, {-5, 0}, nullptr);
+            stopwatch1ResetButton->GetComponent<UI::LayoutElement*>()->set_ignoreLayout(true);
+            stopwatch1ResetButton->get_transform()->set_localScale({0.9, 0.9, 0.9});
+            stopwatch1ResetButton->get_onClick()->AddListener(custom_types::MakeDelegate<Events::UnityAction*>(std::function<void()>([](){
+                if(ClockMod::ClockUpdater::getInstance()) ClockMod::ClockUpdater::getInstance()->resetStopwatch1();
+            })));
+
+            auto stopwatch2PauseButton = BSML::Lite::CreateUIButton(parent, getModConfig().Stopwatch2Paused.GetValue() ? "Start" : "Pause", {70, -25.5}, {-5, 0}, nullptr);
+            stopwatch2PauseButton->GetComponent<UI::LayoutElement*>()->set_ignoreLayout(true);
+            stopwatch2PauseButton->get_transform()->set_localScale({0.9, 0.9, 0.9});
+            stopwatch2PauseButton->get_onClick()->AddListener(custom_types::MakeDelegate<Events::UnityAction*>(std::function<void()>([stopwatch2PauseButton](){
+                getModConfig().Stopwatch2Paused.SetValue(!getModConfig().Stopwatch2Paused.GetValue());
+                if(getModConfig().Stopwatch2Paused.GetValue()) BSML::Lite::SetButtonText(stopwatch2PauseButton, "Start");
+                else BSML::Lite::SetButtonText(stopwatch2PauseButton, "Pause");
+            })));
+            auto stopwatch2ResetButton = BSML::Lite::CreateUIButton(parent, "Reset", {83.5, -25.5}, {-5, 0}, nullptr);
+            stopwatch2ResetButton->GetComponent<UI::LayoutElement*>()->set_ignoreLayout(true);
+            stopwatch2ResetButton->get_transform()->set_localScale({0.9, 0.9, 0.9});
+            stopwatch2ResetButton->get_onClick()->AddListener(custom_types::MakeDelegate<Events::UnityAction*>(std::function<void()>([](){
+                if(ClockMod::ClockUpdater::getInstance()) ClockMod::ClockUpdater::getInstance()->resetStopwatch2();
             })));
 
             AddConfigValueDropdownEnum(parent, getModConfig().ClockType, clockTypeStrs);

--- a/src/ClockViewContoller.cpp
+++ b/src/ClockViewContoller.cpp
@@ -51,10 +51,9 @@ namespace ClockMod {
             strftime(UTCtime, sizeof(UTCtime), std::string("\r\nCurrent Time in UTC -  " + ClockUpdater::getTimeFormat()).c_str(), ClockUpdater::getInstance()->getTimeInfoUTC());
             //strftime(UTCtime, sizeof(UTCtime), std::string("\r\n Current Time in UTC -  " + ClockUpdater::getTimeFormat()).c_str(), gmtime(ClockUpdater::getInstance()->getRawTime()));
             
-            std::string sessionTime = "\nSession Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getSessionTimeSeconds());
-
-            std::string stopwatch1Time = "\nStopwatch 1 Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getStopwatch1Seconds());
-            std::string stopwatch2Time = "\nStopwatch 2 Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getStopwatch2Seconds());
+            std::string sessionTime = "\nSession Time -  " + ClockUpdater::getStopwatchString(ClockUpdater::getInstance()->getSessionTimeSeconds());
+            std::string stopwatch1Time = "\nStopwatch 1 Time -  " + ClockUpdater::getStopwatchString(ClockUpdater::getInstance()->getStopwatch1Seconds());
+            std::string stopwatch2Time = "\nStopwatch 2 Time -  " + ClockUpdater::getStopwatchString(ClockUpdater::getInstance()->getStopwatch2Seconds());
 
             if (TimeInfo && SettingsOpen)
                 TimeInfo->set_text(std::string(timeInformation) + UTCtime + sessionTime + stopwatch1Time + stopwatch2Time);

--- a/src/ClockViewContoller.cpp
+++ b/src/ClockViewContoller.cpp
@@ -45,7 +45,7 @@ namespace ClockMod {
             strftime(timeInformation, sizeof(timeInformation), "Your Timezone -  %Z    UTC offset -  %z", ClockUpdater::getInstance()->getTimeInfo());
 
             char UTCtime[40];
-            strftime(UTCtime, sizeof(UTCtime), std::string("\r\n Current Time in UTC -  " + ClockUpdater::getTimeFormat()).c_str(), ClockUpdater::getInstance()->getTimeInfoUTC());
+            strftime(UTCtime, sizeof(UTCtime), std::string("\r\nCurrent Time in UTC -  " + ClockUpdater::getTimeFormat()).c_str(), ClockUpdater::getInstance()->getTimeInfoUTC());
             //strftime(UTCtime, sizeof(UTCtime), std::string("\r\n Current Time in UTC -  " + ClockUpdater::getTimeFormat()).c_str(), gmtime(ClockUpdater::getInstance()->getRawTime()));
             
             std::string sessionTime = "\nSession Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getSessionTime());

--- a/src/ClockViewContoller.cpp
+++ b/src/ClockViewContoller.cpp
@@ -42,11 +42,15 @@ namespace ClockMod {
         while (SettingsOpen) {
             char timeInformation[45];
             strftime(timeInformation, sizeof(timeInformation), "Your Timezone -  %Z    UTC offset -  %z", ClockUpdater::getInstance()->getTimeInfo());
+
             char UTCtime[40];
             strftime(UTCtime, sizeof(UTCtime), std::string("\r\n Current Time in UTC -  " + ClockUpdater::getTimeFormat()).c_str(), ClockUpdater::getInstance()->getTimeInfoUTC());
             //strftime(UTCtime, sizeof(UTCtime), std::string("\r\n Current Time in UTC -  " + ClockUpdater::getTimeFormat()).c_str(), gmtime(ClockUpdater::getInstance()->getRawTime()));
+            
+            std::string sessionTime = "\nSession Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getSessionTime());
+
             if (TimeInfo && SettingsOpen)
-                TimeInfo->set_text(std::string(timeInformation) + UTCtime);
+                TimeInfo->set_text(std::string(timeInformation) + UTCtime + sessionTime);
             co_yield reinterpret_cast<System::Collections::IEnumerator*>(UnityEngine::WaitForSecondsRealtime::New_ctor(0.1));
         }
         co_return;
@@ -67,7 +71,7 @@ namespace ClockMod {
                 std::string timeFormat = "Your Timezone -  %Z\nUTC offset -  %z";
                 strftime(timeInformation, sizeof(timeInformation), timeFormat.c_str(), instance->getTimeInfo());
                 // We have to specify sizeDelta here otherwise things will overlap
-                TimeInfo = BSML::Lite::CreateText(parent, std::string(timeInformation), TMPro::FontStyles::Normal, {0,0}, {0,15});
+                TimeInfo = BSML::Lite::CreateText(parent, std::string(timeInformation), TMPro::FontStyles::Normal, {0,0}, {0,20});
                 // TimeInfo = BSML::Lite::CreateText(parent, std::string(timeInformation), TMPro::FontStyles::Normal);
 
                 ColorPicker = BSML::Lite::CreateColorPickerModal(parent, getModConfig().ClockColor.GetName(), getModConfig().ClockColor.GetValue(),

--- a/src/ClockViewContoller.cpp
+++ b/src/ClockViewContoller.cpp
@@ -10,6 +10,7 @@ using namespace ClockMod;
 #include "bsml/shared/BSML/Components/ModalColorPicker.hpp"
 #include "custom-types/shared/coroutine.hpp"
 #include "custom-types/shared/macros.hpp"
+#include "custom-types/shared/delegate.hpp"
 
 #include "HMUI/CurvedTextMeshPro.hpp"
 #include "HMUI/ScrollView.hpp"
@@ -23,6 +24,8 @@ using namespace ClockMod;
 #include "UnityEngine/Canvas.hpp"
 #include "UnityEngine/Color.hpp"
 #include "UnityEngine/GameObject.hpp"
+#include "UnityEngine/UI/Button.hpp"
+#include "UnityEngine/UI/LayoutElement.hpp"
 #include "UnityEngine/WaitForSecondsRealtime.hpp"
 
 
@@ -89,6 +92,19 @@ namespace ClockMod {
                     }
                     );
             }
+
+            auto stopwatchPauseButton = BSML::Lite::CreateUIButton(parent, getModConfig().StopwatchPaused.GetValue() ? "Start" : "Pause", {68, -19.9}, {-5, 0}, nullptr);
+            stopwatchPauseButton->GetComponent<UI::LayoutElement*>()->set_ignoreLayout(true);
+            stopwatchPauseButton->get_onClick()->AddListener(custom_types::MakeDelegate<Events::UnityAction*>(std::function<void()>([stopwatchPauseButton](){
+                getModConfig().StopwatchPaused.SetValue(!getModConfig().StopwatchPaused.GetValue());
+                if(getModConfig().StopwatchPaused.GetValue()) BSML::Lite::SetButtonText(stopwatchPauseButton, "Start");
+                else BSML::Lite::SetButtonText(stopwatchPauseButton, "Pause");
+            })));
+            auto stopwatchResetButton = BSML::Lite::CreateUIButton(parent, "Reset", {83, -19.9}, {-5, 8}, nullptr);
+            stopwatchResetButton->GetComponent<UI::LayoutElement*>()->set_ignoreLayout(true);
+            stopwatchResetButton->get_onClick()->AddListener(custom_types::MakeDelegate<Events::UnityAction*>(std::function<void()>([](){
+                if(ClockMod::ClockUpdater::getInstance()) ClockMod::ClockUpdater::getInstance()->resetStopwatch();
+            })));
 
             AddConfigValueDropdownEnum(parent, getModConfig().ClockType, clockTypeStrs);
             AddConfigValueToggle(parent, getModConfig().InSong);

--- a/src/ClockViewContoller.cpp
+++ b/src/ClockViewContoller.cpp
@@ -50,8 +50,10 @@ namespace ClockMod {
             
             std::string sessionTime = "\nSession Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getSessionTimeSeconds());
 
+            std::string stopwatchTime = "\nStopwatch Time -  " + ClockUpdater::getTimerString(ClockUpdater::getInstance()->getStopwatchSeconds());
+
             if (TimeInfo && SettingsOpen)
-                TimeInfo->set_text(std::string(timeInformation) + UTCtime + sessionTime);
+                TimeInfo->set_text(std::string(timeInformation) + UTCtime + sessionTime + stopwatchTime);
             co_yield reinterpret_cast<System::Collections::IEnumerator*>(UnityEngine::WaitForSecondsRealtime::New_ctor(0.1));
         }
         co_return;
@@ -72,7 +74,7 @@ namespace ClockMod {
                 std::string timeFormat = "Your Timezone -  %Z\nUTC offset -  %z";
                 strftime(timeInformation, sizeof(timeInformation), timeFormat.c_str(), instance->getTimeInfo());
                 // We have to specify sizeDelta here otherwise things will overlap
-                TimeInfo = BSML::Lite::CreateText(parent, std::string(timeInformation), TMPro::FontStyles::Normal, {0,0}, {0,20});
+                TimeInfo = BSML::Lite::CreateText(parent, std::string(timeInformation), TMPro::FontStyles::Normal, {0,0}, {0,5*5});
                 // TimeInfo = BSML::Lite::CreateText(parent, std::string(timeInformation), TMPro::FontStyles::Normal);
 
                 ColorPicker = BSML::Lite::CreateColorPickerModal(parent, getModConfig().ClockColor.GetName(), getModConfig().ClockColor.GetValue(),

--- a/src/ClockViewContoller.cpp
+++ b/src/ClockViewContoller.cpp
@@ -1,5 +1,6 @@
 #include "ClockModConfig.hpp"
 #include "ClockUpdater.hpp"
+#include "ClockValues.hpp"
 #include "ClockViewController.hpp"
 using namespace ClockMod;
 
@@ -87,6 +88,7 @@ namespace ClockMod {
                     );
             }
 
+            AddConfigValueDropdownEnum(parent, getModConfig().ClockType, clockTypeStrs);
             AddConfigValueToggle(parent, getModConfig().InSong);
             AddConfigValueToggle(parent, getModConfig().InReplay);
             AddConfigValueToggle(parent, getModConfig().TwelveToggle);


### PR DESCRIPTION
Someone requested an elapsed time mod in the BSMG Discord server, something to replace Move after it was discontinued. I liked the idea and figured it would fit in nicely into Clock Mod.

- Added a session timer
- Added two stopwatches that can be paused, reset, and are saved to the mod config
- Display the extra information at the top of `ClockViewController`
- Added a dropdown for the floating clock to display current time, session time, or either of the two stopwatches

The stopwatches are useful for recording session time without crashes, emulating the discontinued Move app, timing how long it takes to achieve some goal, etc.
I was going to follow whatever style guide was used in the rest of the mod, but consistency appears to have already been thrown out the window...
Oh I also updated the mod version from v1.11.0-Dev to v1.15.0-Dev in the qpm files. Seems like that step was forgotten in the previous bump versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable clock modes: Current Time, Session Time, Stopwatch 1, Stopwatch 2.
  * Two independent stopwatches with Pause/Start, Reset, and periodic persistence.
  * Session time tracking and improved long-duration time formatting.

* **UI/UX**
  * Clock Type dropdown and stopwatch controls in settings.
  * Session/stopwatch times appended to Time Info; layout spacing and UTC formatting refined.

* **Chores**
  * Package version bumped to 1.15.0-Dev.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->